### PR TITLE
Enhancement: Use Docker image with PHP 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`34c52fe...master`](https://github.com/localheinz/composer-require-checker-action/compare/34c52fe...master).
+For a full diff see [`1.1.0...master`](https://github.com/localheinz/composer-require-checker-action/compare/1.1.0...master).
+
+### [`1.1.0`][1.1.0]
+
+For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0].
+
+#### Changed
+
+* Used `php:7.4-cli-alpine` instead of `php:7.3-cli-alpine` as base Docker image ([#2]), by [@localheinz]
+
+### [`1.0.0`][1.0.0]
+
+For a full diff see [`34c52fe...1.0.0`][34c52fe...1.0.0].
+
+[1.0.0]: https://github.com/localheinz/localheinz/composer-require-checker-action/releases/tag/1.0.0
+[1.1.0]: https://github.com/localheinz/localheinz/composer-require-checker-action/releases/tag/1.1.0
+
+[34c52fe...1.0.0]: https://github.com/localheinz/composer-require-checker-action/compare/34c52fe...1.0.0
+[1.0.0...1.1.0]: https://github.com/localheinz/composer-require-checker-action/compare/1.0.0...1.1.0
+
+[#2]: https://github.com/localheinz/composer-require-checker-action/pull/2
+
+[@localheinz]: https://github.com/localheinz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-cli-alpine
+FROM php:7.4-cli-alpine
 
 LABEL "repository"="https://github.com/localheinz/composer-require-checker-action"
 LABEL "homepage"="https://github.com/localheinz/composer-require-checker-action"


### PR DESCRIPTION
This PR

* [x] uses `php:7.4-cli-alpine` instead of `php:7.3-cli-alpine` as a Docker base image
