### PR TITLE
Fix: Wrap environment variables in curly braces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT=2.0.0
 
 COPY memory.ini /usr/local/etc/php/conf.d/memory.ini
 
-RUN composer global require maglnet/composer-require-checker:$COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT --no-interaction --no-progress --no-suggest
+RUN composer global require maglnet/composer-require-checker:${COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT} --no-interaction --no-progress --no-suggest
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
-if [ -n "$COMPOSER_REQUIRE_CHECKER_VERSION" ] && [ "$COMPOSER_REQUIRE_CHECKER_VERSION" != "$COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT" ]; then
-  composer global require maglnet/composer-require-checker:"$COMPOSER_REQUIRE_CHECKER_VERSION" --no-interaction --no-progress --no-suggest;
+if [ -n "${COMPOSER_REQUIRE_CHECKER_VERSION}" ] && [ "${COMPOSER_REQUIRE_CHECKER_VERSION}" != "${COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT}" ]; then
+  composer global require maglnet/composer-require-checker:"${COMPOSER_REQUIRE_CHECKER_VERSION}" --no-interaction --no-progress --no-suggest;
 fi
 
 if [ "$HOME" != '/root' ]; then


### PR DESCRIPTION
This PR

* [x] wraps environment variables in curly braces