### PR TITLE
Enhancement: Add version input parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.1.1...master`](https://github.com/localheinz/composer-require-checker-action/compare/1.1.1...master).
 
+### Added
+
+* Added `version` input parameter which allows specifying a version constraint for installing `maglnet/composer-require-checker` when necessary ([#5]), by [@localheinz]
+
 ### [`1.1.1`][1.1.1]
 
 For a full diff see [`1.1.0...1.1.1`][1.1.0...1.1.1].
@@ -38,5 +42,6 @@ For a full diff see [`34c52fe...1.0.0`][34c52fe...1.0.0].
 
 [#2]: https://github.com/localheinz/composer-require-checker-action/pull/2
 [#3]: https://github.com/localheinz/composer-require-checker-action/pull/3
+[#5]: https://github.com/localheinz/composer-require-checker-action/pull/5
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ name: "Continuous Integration"
 jobs:
   dependency-analysis:
     name: "Dependency Analysis"
-    
+
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@master
@@ -64,9 +64,9 @@ Instead of using the latest pre-built Docker image, you can also specify a Docke
  jobs:
    composer-require-checker-action:
      name: composer-require-checker-action
-    
+
      runs-on: ubuntu-latest
-    
+
      steps:
        - name: "Checkout"
          uses: actions/checkout@master
@@ -76,6 +76,38 @@ Instead of using the latest pre-built Docker image, you can also specify a Docke
 +        uses: docker://localheinz/composer-require-checker-action:1.2.3
 ```
 
+## Inputs
+
+### `version`
+
+If you prefer to use a different version of `maglnet/composer-require-checker`, you can specify it using the `version` input:
+
+```diff
+ on:
+   pull_request:
+   push:
+     branches:
+       - master
+     tags:
+       - "**"
+
+ name: "Continuous Integration"
+
+ jobs:
+   composer-require-checker-action:
+     name: composer-require-checker-action
+
+     runs-on: ubuntu-latest
+
+     steps:
+       - name: "Checkout"
+         uses: actions/checkout@master
+
+       - name: "Run action"
+         uses: docker://localheinz/composer-require-checker-action:latest
++        with:
++          version: "^1.1.0"
+```
 ## Changelog
 
 Please have a look at [`CHANGELOG.md`](CHANGELOG.md).

--- a/action.yml
+++ b/action.yml
@@ -13,3 +13,9 @@ author: 'localheinz'
 runs:
   using: 'docker'
   image: 'docker://localheinz/composer-require-checker-action'
+
+inputs:
+  version:
+    description: 'Version constraint for maglnet/composer-require-checker'
+    required: false
+    default: '^2.0.0'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
-if [ -n "${COMPOSER_REQUIRE_CHECKER_VERSION}" ] && [ "${COMPOSER_REQUIRE_CHECKER_VERSION}" != "${COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT}" ]; then
-  composer global require maglnet/composer-require-checker:"${COMPOSER_REQUIRE_CHECKER_VERSION}" --no-interaction --no-progress --no-suggest;
+if [ "${INPUT_VERSION}" != "${COMPOSER_REQUIRE_CHECKER_VERSION_DEFAULT}" ]; then
+  composer global require maglnet/composer-require-checker:"${INPUT_VERSION}" --no-interaction --no-progress --no-suggest;
 fi
 
 if [ "$HOME" != '/root' ]; then


### PR DESCRIPTION
This PR

* [x] adds a `version` input parameter which allows specifying a version constraint for installing `maglnet/composer-require-checker`, when necessary