### PR TITLE
Fix: Remove workingDirectory input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ For a full diff see [`1.1.1...master`](https://github.com/localheinz/composer-re
 ### Added
 
 * Added `version` input parameter which allows specifying a version constraint for installing `maglnet/composer-require-checker` when necessary ([#5]), by [@localheinz]
-* Added `workingDirectory` input parameter which allows specifying a directory in which to run `maglnet/composer-require-checker` ([#10]), by [@localheinz]
 
 ### [`1.1.1`][1.1.1]
 
@@ -44,6 +43,5 @@ For a full diff see [`34c52fe...1.0.0`][34c52fe...1.0.0].
 [#2]: https://github.com/localheinz/composer-require-checker-action/pull/2
 [#3]: https://github.com/localheinz/composer-require-checker-action/pull/3
 [#5]: https://github.com/localheinz/composer-require-checker-action/pull/5
-[#10]: https://github.com/localheinz/composer-require-checker-action/pull/10
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -108,38 +108,6 @@ If you prefer to use a different version of `maglnet/composer-require-checker`, 
 +        with:
 +          version: "^1.1.0"
 ```
-
-### `workingDirectory`
-
-If `composer.json` is not in the root of your project, you specify the working directory using the `workingDirectory` input:
-
-```diff
- on:
-   pull_request:
-   push:
-     branches:
-       - master
-     tags:
-       - "**"
-
- name: "Continuous Integration"
-
- jobs:
-   composer-require-checker-action:
-     name: composer-require-checker-action
-
-     runs-on: ubuntu-latest
-
-     steps:
-       - name: "Checkout"
-         uses: actions/checkout@master
-
-       - name: "Run action"
-         uses: docker://localheinz/composer-require-checker-action:latest
-+        with:
-+          workingDirectory: "foo/bar"
-```
-
 ## Changelog
 
 Please have a look at [`CHANGELOG.md`](CHANGELOG.md).

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: 'Version constraint for maglnet/composer-require-checker'
     required: false
     default: '^2.0.0'
-  workingDirectory:
-    description: 'Directory in which to run maglnet/composer-require-checker'
-    required: false
-    default: '.'
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,4 @@ if [ "$HOME" != '/root' ]; then
   cp -r /root/.composer "$HOME"/.composer;
 fi
 
-if [ "${INPUT_WORKINGDIRECTORY}" != "." ]; then
-  cd "${INPUT_WORKINGDIRECTORY}" || exit 1
-fi
-
 sh -c "$HOME/.composer/vendor/bin/composer-require-checker check $*"


### PR DESCRIPTION
This PR

* [x] reverts #10

🤦‍♂ For reference, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun:

![Screen Shot 2019-12-16 at 18 06 03](https://user-images.githubusercontent.com/605483/70927137-bd049500-202e-11ea-9fc0-3e19d8221edf.png)
